### PR TITLE
Fixed readme to show right way to grab versions from github

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Terraform module that creates an S3 bucket and DynamoDB table for backend state 
 ```hcl
 module "backend-s3" {
   source = "github.com/byu-oit/terraform-aws-backend-s3"
-  version = "1.0.1"
+  ref = "v1.0.2"
 }
 ```
 

--- a/examples/example.tf
+++ b/examples/example.tf
@@ -3,7 +3,8 @@ provider "aws" {
 }
 
 module "backend-s3" {
-  source = "../"
+  source = "github.com/byu-oit/terraform-aws-backend-s3"
+  ref = "v1.0.2"
 }
 
 output "s3" {


### PR DESCRIPTION
From slack conversation we need to use the "ref" attribute instead of "version" attribute when using modules from github. Correct?